### PR TITLE
Fix section show serializer to respond with image's url

### DIFF
--- a/app/serializers/section/show_serializer.rb
+++ b/app/serializers/section/show_serializer.rb
@@ -1,12 +1,29 @@
 class Section::ShowSerializer < ActiveModel::Serializer
-  attributes :variant, :header, :view_id, :id 
+  include Rails.application.routes.url_helpers
+  attributes :variant, :header, :view_id, :id
 
   def attributes(*args)
     hash = super
     hash[:buttons] = object.buttons if object.regular?
     hash[:description] = object.description unless object.carousel?
+    hash[:image] = image if object.regular?
     hash[:cards] = object.cards if object.carousel?
-    hash[:image] = object.image if object.regular?
     hash 
+  end
+
+  private
+
+  def image
+    return unless object.image
+
+    url = if Rails.env.test? || Rails.env.development?
+            rails_blob_path(object.image.file, only_path: true)
+          else
+            object.image.file.url(expires_in: 1.hour, disposition: 'inline')
+          end
+    {
+      url: url,
+      alt: object.image.alt_text
+    }
   end
 end

--- a/spec/serilizers/section/show_serializer_spec.rb
+++ b/spec/serilizers/section/show_serializer_spec.rb
@@ -24,8 +24,9 @@ RSpec.describe Section::ShowSerializer, type: :serializer do
       expect(subject['sections'].last.keys).to match expected_keys
     end
 
-    it 'is expected to contain attached image' do
-      expect(subject['sections'].first['image']['id']).to eq image_1.id
+    it 'is expected to contain image url' do
+      expected_extension = '.jpeg'
+      expect(subject['sections'].first['image']['url']).to include expected_extension
     end
   end
 


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/179783888
### Change
- includes url and alt attrs in section response object